### PR TITLE
Addition: New Use Case Compute Time

### DIFF
--- a/src/main/java/use_case/compute_time/ComputeTimeDataAccessInterface.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeDataAccessInterface.java
@@ -1,0 +1,7 @@
+package use_case.compute_time;
+
+/**
+ * DAO for the Compute Time Use Case.
+ */
+public interface ComputeTimeDataAccessInterface {
+}

--- a/src/main/java/use_case/compute_time/ComputeTimeInputBoundary.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeInputBoundary.java
@@ -1,5 +1,13 @@
 package use_case.compute_time;
 
+/**
+ * Input Boundary for actions which are related to computing itinerary time.
+ */
 public interface ComputeTimeInputBoundary {
 
+    /**
+     * Executes the Compute Time Use Case.
+     * @param computeTimeInputData the input data
+     */
+    void execute(ComputeTimeInputData computeTimeInputData);
 }

--- a/src/main/java/use_case/compute_time/ComputeTimeInputData.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeInputData.java
@@ -1,0 +1,55 @@
+package use_case.compute_time;
+
+import entity.AttractionData;
+
+import java.util.List;
+
+/**
+ * The ComputeTimeInputData class represents the input data required for the "Compute Time" use case.
+ * It contains the sequence of attractions to be visited, as well as the start and end times for the visit.
+ */
+public class ComputeTimeInputData {
+    private final List<AttractionData> sequentialLocations;
+    private final double startTime;
+    private final double endTime;
+
+    /**
+     * Constructs a ComputeTimeInputData object with the specified locations, start time, and end time.
+     *
+     * @param sequentialLocations A list of {@link AttractionData} objects representing the locations to visit.
+     * @param startTime           The start time for the visit in decimal hours.
+     * @param endTime             The end time for the visit in decimal hours.
+     */
+    public ComputeTimeInputData(List<AttractionData> sequentialLocations, double startTime, double endTime) {
+        this.sequentialLocations = sequentialLocations;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    /**
+     * Retrieves the sequence of locations to visit.
+     *
+     * @return A list of {@link AttractionData} objects representing the locations to visit.
+     */
+    public List<AttractionData> getSequentialLocations() {
+        return sequentialLocations;
+    }
+
+    /**
+     * Retrieves the start time for the visit.
+     *
+     * @return The start time in decimal hours.
+     */
+    public double getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * Retrieves the end time for the visit.
+     *
+     * @return The end time in decimal hours.
+     */
+    public double getEndTime() {
+        return endTime;
+    }
+}

--- a/src/main/java/use_case/compute_time/ComputeTimeInteractor.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeInteractor.java
@@ -1,18 +1,96 @@
 package use_case.compute_time;
 
 import java.util.List;
-import entity.LocationData;
-import use_case.find_shortest_path.FindShortestPathOutputBoundary;
+import entity.AttractionData;
 
+/**
+ * The ComputeTimeInteractor class implements the business logic for the "Compute Time" use case.
+ * It calculates travel times and visit times for a sequence of attractions based on user input.
+ */
 public class ComputeTimeInteractor implements ComputeTimeInputBoundary{
+    private final ComputeTimeDataAccessInterface computeTimeDataAccessInterface;
     private final ComputeTimeOutputBoundary outputBoundary;
-    private final List<LocationData> sequentialLocations;
 
-    public ComputeTimeInteractor(List<LocationData> sequentialLocations,
-                                      ComputeTimeOutputBoundary outputBoundary) {
-        this.sequentialLocations = sequentialLocations;
+    /**
+     * Constructs a ComputeTimeInteractor with the specified data access and output boundary.
+     *
+     * @param computeTimeDataAccessInterface The data access interface for travel time data.
+     * @param outputBoundary                 The output boundary for presenting results.
+     */
+    public ComputeTimeInteractor(ComputeTimeDataAccessInterface computeTimeDataAccessInterface,
+                                 ComputeTimeOutputBoundary outputBoundary) {
+        this.computeTimeDataAccessInterface = computeTimeDataAccessInterface;
         this.outputBoundary = outputBoundary;
     }
 
+    /**
+     * Converts a time value from decimal hours to a formatted string (HH:mm).
+     *
+     * @param time The time in decimal hours.
+     * @return A string representing the time in HH:mm format.
+     * If hours or minutes is single digit, 0 will appear in front of it.
+     */
+    private String timeConvert(double time) {
+        Double minutes = Math.floor((time - Math.floor(time)) * 60);
+        Double hours = Math.floor(time);
+
+        return String.format("%02d:%02d", hours.intValue(), minutes.intValue());
+    }
+
+    /**
+     * Calculates the total travel time for a sequence of attractions.
+     *
+     * @param sequentialLocations A list of {@link AttractionData} objects representing the locations.
+     * @return The total travel time in minutes.
+     */
+    private Double getTotalTravelTime(List<AttractionData> sequentialLocations) {
+//        Double result = startingLocation.getTravelTime() * 60.0;
+        double result = 0.0;
+
+        for (AttractionData node : sequentialLocations) {
+            result += node.getTravelTime() * 60.0;
+        }
+        return result;
+    }
+
+    /**
+     * Fills the visit times for a sequence of attractions based on start and end times.
+     *
+     * @param startTime           The start time in decimal hours.
+     * @param endTime             The end time in decimal hours.
+     * @param sequentialLocations A list of {@link AttractionData} objects to be updated.
+     * @return A list of {@link AttractionData} objects with updated visit times.
+     */
+    private List<AttractionData> fillSequentialLocations(double startTime, double endTime, List<AttractionData> sequentialLocations) {
+        // subtract one assuming that the starting location is also included, and we are not spending time there.
+        double timeAtEachLocation = Math.floor((endTime - startTime - getTotalTravelTime(sequentialLocations)) / sequentialLocations.size() - 1);
+        double lastTravelTime = sequentialLocations.get(0).getTravelTime() * 60.0;
+        double currentTime = startTime;
+
+        for (int i = 1; i < sequentialLocations.size() - 1; i++) {
+            AttractionData node = sequentialLocations.get(i);
+            String visitTime = timeConvert(currentTime + lastTravelTime) + timeConvert(currentTime + lastTravelTime + timeAtEachLocation);
+            currentTime += lastTravelTime + timeAtEachLocation;
+            node.setVisitTime(visitTime);
+        }
+        String visitTime = timeConvert(currentTime + lastTravelTime) + timeConvert(endTime);
+        sequentialLocations.get(sequentialLocations.size() - 1).setVisitTime(visitTime);
+        return sequentialLocations;
+    }
+
+    /**
+     * Executes the "Compute Time" use case by calculating visit times for a sequence of attractions.
+     *
+     * @param computeTimeInputData The input data containing start time, end time, and attractions.
+     */
+    @Override
+    public void execute(ComputeTimeInputData computeTimeInputData) {
+        List<AttractionData> newSequentialLocations = fillSequentialLocations(
+                computeTimeInputData.getStartTime(),
+                computeTimeInputData.getEndTime(),
+                computeTimeInputData.getSequentialLocations());
+        final ComputeTimeOutputData outputData = new ComputeTimeOutputData(newSequentialLocations, false);
+        outputBoundary.prepareSuccessView(outputData);
+    }
 
 }

--- a/src/main/java/use_case/compute_time/ComputeTimeOutputBoundary.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeOutputBoundary.java
@@ -1,4 +1,17 @@
 package use_case.compute_time;
 
+/**
+ * The output boundary for the Compute Time Use Case.
+ */
 public interface ComputeTimeOutputBoundary {
-}
+    /**
+     * Prepares the success view for the Compute Time Use Case.
+     * @param outputData the output data
+     */
+    void prepareSuccessView(ComputeTimeOutputData outputData);
+
+
+     /** Prepares the failure view for the Compute Time Use Case.
+      *  @param errorMessage the explanation of the failure
+     */
+    void prepareFailView(String errorMessage);}

--- a/src/main/java/use_case/compute_time/ComputeTimeOutputData.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeOutputData.java
@@ -1,0 +1,43 @@
+package use_case.compute_time;
+
+import entity.AttractionData;
+import java.util.List;
+
+/**
+ * Represents the output data of the "Compute Time" use case.
+ * This class encapsulates a list of sequentially ordered locations and a flag indicating
+ * whether the use case failed.
+ */
+public class ComputeTimeOutputData {
+    private final List<AttractionData> sequentialLocations;
+    private final boolean useCaseFailed;
+
+    /**
+     * Constructs a ComputeTimeOutputData object with the provided list of locations and failure status.
+     *
+     * @param sequentialLocations A list of sequentially ordered {@link AttractionData} objects.
+     * @param useCaseFailed       A boolean indicating whether the use case failed.
+     */
+    public ComputeTimeOutputData(List<AttractionData> sequentialLocations, boolean useCaseFailed) {
+        this.sequentialLocations = sequentialLocations;
+        this.useCaseFailed = useCaseFailed;
+    }
+
+    /**
+     * Retrieves the list of sequential locations.
+     *
+     * @return A list of {@link AttractionData} objects in sequential order.
+     */
+    public List<AttractionData> getSequentialLocations() {
+        return sequentialLocations;
+    }
+
+    /**
+     * Checks whether the use case failed.
+     *
+     * @return true if the use case failed; false otherwise.
+     */
+    public boolean isUseCaseFailed() {
+        return useCaseFailed;
+    }
+}


### PR DESCRIPTION
Addition: New Use Case Compute Time, computes the time between each attraction, factoring in start time, end time, and travel time.

`compute_time` (Previously known as `prepare_locations` on the Design Doc): calculates the time the user spends at each location that needs to be displayed to the user when we show them their itinerary. 

Pre-condition: An ordered array of `attractionData` which includes filled out travelTime and the sequential order at which a player would travel to each attraction. 
Post-condition: An array of `attractionData`, which has filled in `attractionData`'s `visitTime` private variable, which is the final formatted time that will be displayed along with the attraction name and location in the DisplayItinerary view.

This use case is called after FindShortestPath has been called and has returned a filled sequential path. This use case is used in the DisplayItinerary view.  

**Update**
This use case used to take in double objects for the start time and end time. Now it has been changed to Date objects, this adheres to the same object type as the entities that store start time and end time.
