### PR TITLE
Speed up DisplayOptionsView load time by loading images asynchronously

### DIFF
--- a/homework-5.iml
+++ b/homework-5.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$" dumb="true">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/test" isTestSource="true" />
-    </content>
-  </component>
-</module>

--- a/src/main/java/use_case/compute_time/ComputeTimeInteractor.java
+++ b/src/main/java/use_case/compute_time/ComputeTimeInteractor.java
@@ -73,7 +73,7 @@ public class ComputeTimeInteractor implements ComputeTimeInputBoundary{
 
         double lastTravelTime = sequentialLocations.get(0).getTravelTime();
         sequentialLocations.get(0).setVisitTime(timeConvert(startTime));
-        for (int i = 0; i < sequentialLocations.size() - 1; i++) {
+        for (int i = 1; i < sequentialLocations.size(); i++) {
             AttractionData node = sequentialLocations.get(i);
 
             calendar.add(Calendar.MINUTE, (int) lastTravelTime);

--- a/src/main/java/view/DisplayOptionsView.java
+++ b/src/main/java/view/DisplayOptionsView.java
@@ -12,6 +12,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -114,7 +117,7 @@ public class DisplayOptionsView extends JPanel implements ActionListener, Proper
         System.out.println("Click " + evt.getActionCommand());
     }
 
-    public String checkBoxBuilder(String name, String type, String address, String price, String rating, String imageUrl) {
+    private String checkBoxBuilder(String name, String type, String address, String price, String rating, String imageUrl) {
         if (Objects.equals(price, "0")){
             price = "";
         } else {
@@ -125,9 +128,7 @@ public class DisplayOptionsView extends JPanel implements ActionListener, Proper
 
         final StringBuilder cssStyle = new StringBuilder();
         cssStyle.append("<html>");
-        cssStyle.append("<link href='https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap' rel='stylesheet'>");
         cssStyle.append("<style>");
-        cssStyle.append("img { float: left; margin-right: 10px; }");
         cssStyle.append("body { font-family: 'Montserrat', sans-serif; padding: 20px; }");
         cssStyle.append("h1 { color: #52796F; font-size: 14px; }");
         cssStyle.append("h2 { margin-top: 0; margin-bottom: 5px; font-size: 10px; }");
@@ -137,16 +138,13 @@ public class DisplayOptionsView extends JPanel implements ActionListener, Proper
         cssStyle.append("</style>");
 
         return  cssStyle +
-                "<div style='border-left: 4px solid #52796F; padding-left: 10px;'>" +
-                "<div class='parent'>" +
-                    "<div class='child'>" +
-                    "<img src='" + imageUrl + "' width='120' height='120' style='margin-left: 10px;'/>" +
-                    "</div>" +
-                    "<div class='child'>" +
+                "<div class='item'>" +
+                        "<img src='" + imageUrl + "' width='120' height='120' />" +  // Image on the left
+                        "<div class='text'>" +
                         "<h1>" + name + "</h1>" +
                         "<h2>" + type + " - " + price + rating + "</h2>" +
                         "<p>" + address + "</p>" +
-                    "</div>" +
+                        "</div>" +
                 "</div>" +
                 "</html>";
     }
@@ -157,6 +155,8 @@ public class DisplayOptionsView extends JPanel implements ActionListener, Proper
             final DisplayOptionsState state = (DisplayOptionsState) evt.getNewValue();
 
             resultsCheckboxes.removeAll();
+            List<AttractionData> locations = new ArrayList<>();
+            List<JCheckBox> checkBoxes = new ArrayList<>();
             for (AttractionData possibleLocation : state.getCheckedLocationList().keySet()) {
                 JCheckBox checkBox = new JCheckBox(checkBoxBuilder(
                         possibleLocation.getName(),
@@ -164,31 +164,13 @@ public class DisplayOptionsView extends JPanel implements ActionListener, Proper
                         possibleLocation.getAddress(),
                         String.valueOf(possibleLocation.getPrice()),
                         String.valueOf(possibleLocation.getRating()),
-                        possibleLocation.getPhotoUrl()
+                        ""
+//                        possibleLocation.getPhotoUrl()
                 ));
 
-//                JPanel container = new JPanel();
-//                container.setLayout(new BoxLayout(container, BoxLayout.X_AXIS));
-//                JPanel panelOne = new JPanel();
-//                JPanel panelTwo = new JPanel();
-//
-//                panelTwo.setLayout(new BorderLayout()); // Set layout for the panel
-//
-//                String html = "<html>" + "<img src='" + possibleLocation.getPhotoUrl() + "' width='150' height='150'/>" + "</html>";
-//
-//                // Add the HTML to a JLabel
-//                JLabel htmlLabel = new JLabel(html);
-//                htmlLabel.setHorizontalAlignment(SwingConstants.CENTER);
-//
-//                panelOne.add(htmlLabel);
-//                panelTwo.add(checkBox);
-//
-//
-//                container.setLayout(new GridLayout(1,2));
-//                container.add(panelOne, BorderLayout.WEST);
-//                container.add(panelTwo, BorderLayout.CENTER);
-
                 resultsCheckboxes.add(checkBox);
+                locations.add(possibleLocation);
+                checkBoxes.add(checkBox);
 
                 // Sample code for checkbox listeners
                 checkBox.addActionListener(new ActionListener() {
@@ -198,10 +180,88 @@ public class DisplayOptionsView extends JPanel implements ActionListener, Proper
                         state.setCheckedLocation(possibleLocation, source.isSelected());
                     }
                 });
+
+//                loadImageAsync(checkBox, possibleLocation);
             }
+            Timer imageLoadTimer = new Timer(100, new ActionListener() {
+                int currentIndex = 0;
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    // If all images are loaded, stop the Timer
+                    if (currentIndex >= locations.size()) {
+                        ((Timer) e.getSource()).stop();
+                        System.out.println("Done loading images");
+                        return;
+                    }
+
+                    // Get the current location and checkbox to load the image
+                    AttractionData possibleLocation = locations.get(currentIndex);
+                    JCheckBox checkBox = checkBoxes.get(currentIndex);
+
+                    // Load the image for the current location
+                    loadImageAsync(checkBox, possibleLocation);
+
+                    // Increment the index to load the next image in the next cycle
+                    currentIndex++;
+                }
+            });
+
+            imageLoadTimer.start();
 
             errorLabel.setText(state.getErrorText());
         }
+    }
+
+    private void loadImageAsync(JCheckBox checkBox, AttractionData possibleLocation) {
+        SwingWorker<ImageIcon, Void> worker = new SwingWorker<ImageIcon, Void>() {
+            @Override
+            protected ImageIcon doInBackground() {
+                String imageUrl = possibleLocation.getPhotoUrl();
+                if (imageUrl == null || imageUrl.trim().isEmpty()) {
+                    return null;
+                }
+                try {
+                    return new ImageIcon(new URL(imageUrl));
+                } catch (Exception e) {
+                    return null;
+                }
+            }
+
+            @Override
+            protected void done() {
+                try {
+                    ImageIcon image = get();  // Get the loaded image
+                    if (image != null) {
+                        // Update the checkbox with the loaded image
+                        String htmlContent = checkBoxBuilder(
+                                possibleLocation.getName(),
+                                possibleLocation.getCategories().get(0),
+                                possibleLocation.getAddress(),
+                                String.valueOf(possibleLocation.getPrice()),
+                                String.valueOf(possibleLocation.getRating()),
+                                image.getDescription()
+                        );
+                        checkBox.setText(htmlContent);  // Set the HTML content with the image
+                    } else {
+                        // If the image failed to load, just update with no image
+                        String htmlContent = checkBoxBuilder(
+                                possibleLocation.getName(),
+                                possibleLocation.getCategories().get(0),
+                                possibleLocation.getAddress(),
+                                String.valueOf(possibleLocation.getPrice()),
+                                String.valueOf(possibleLocation.getRating()),
+                                ""  // No image URL
+                        );
+                        checkBox.setText(htmlContent);  // Set the HTML content without the image
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();  // Handle exceptions if necessary
+                }
+            }
+        };
+
+        worker.execute();  // Execute the SwingWorker in the background
     }
 
     public DisplayOptionsController getDisplayOptionsController() {

--- a/src/test/java/use_case/compute_time/ComputeTimeInteractorTest.java
+++ b/src/test/java/use_case/compute_time/ComputeTimeInteractorTest.java
@@ -44,6 +44,9 @@ public class ComputeTimeInteractorTest {
             @Override
             public void prepareSuccessView(ComputeTimeOutputData outputData) {
                 assertEquals(attraction1.getVisitTime(), "12:12 - 13:35");
+                assertEquals(attraction2.getVisitTime(), "13:47 - 15:10");
+                assertEquals(attraction3.getVisitTime(), "15:14 - 16:37");
+                assertEquals(attraction4.getVisitTime(), "16:47 - 18:10");
             }
 
             @Override


### PR DESCRIPTION
This pull request implements lazy loading for the images on the Display Options View, which allows the page to be loaded up to 12 times faster than loading all the images at once.

<img width="1182" alt="Screenshot 2024-12-03 at 8 48 33 PM" src="https://github.com/user-attachments/assets/2c634e3b-fb48-462c-95cf-5cf82a08304d">
<img width="1182" alt="Screenshot 2024-12-03 at 8 48 41 PM" src="https://github.com/user-attachments/assets/29828ead-27d1-447b-985a-ca9ac50f19fd">

### Lazy Loading
- Instead of loading all the images at once, which could take up to a minute for 50 individual images given a broad search from the Choose Options page, and making the user wait the entire time before displaying the possible locations, this pull request implements loading the images asynchronously by taking advantage of the `SwingWorker` and `Timer` classes.
- The `SwingWorker` class allows the program to use multiple threads to make requests to load the images in the background while the user is still interacting with the UI of the application, thus allowing the `DisplayOptionsView` page to be loaded immediately once the locations information has been loaded other than the images. In the background, it attempts to load the image and once it is finished, it replaces the html embedded in the corresponding checkbox with one that includes the loaded image.
- The problem with this was that since all the background requests were being made at the same time, they would often return at the same time and once all the embedded html was being replaced, the application would freeze for a couple seconds while all the loaded images were being inserted.
- To solve this, the requests to load the images were spaced out at intervals of 100ms using the `Timer` class, which means that the user's interactions on the `DisplayOptionsView` while the app was running was not interrupted as the images were loaded in one at a time.

### Bug Fixes / Refactoring
- One additional factor decreasing the speed of the page loading was the repeated loading of the Montserrat font, which is actually already included in the default html code and thus the costly operation of loading the font a separate time for each checkbox could be removed
- Fixed a small bug in the Compute Time use case and it's associated test where it was excluding the last location instead of the first
- Deleted the `homework-5.iml` file accidentally included when creating the project should have been included in the `.gitignore`